### PR TITLE
Update Eclipse to 2023-09-R (4.29)

### DIFF
--- a/eclipse-java/eclipse-java.spec
+++ b/eclipse-java/eclipse-java.spec
@@ -46,6 +46,8 @@ for i in 16 22 24 32 48 64 128 256 512 1024 ; do
   install -Dm644 eclipse/plugins/org.eclipse.platform_%{version}*/"eclipse$i.png" "%{buildroot}%{_datadir}/icons/hicolor/${i}x${i}/apps/eclipse.png"
 done
 
+find %{buildroot}%{_eclipsedir}/plugins/com.sun.jna_5.13.0.v20230812-1000/com/sun/jna -type d ! -iname '*linux-x86-64' ! -iname '*jna' | xargs rm -rf
+
 %files
 %{_eclipsedir}
 %{_bindir}/eclipse

--- a/eclipse-java/eclipse-java.spec
+++ b/eclipse-java/eclipse-java.spec
@@ -57,6 +57,7 @@ find %{buildroot}%{_eclipsedir}/plugins/com.sun.jna_5.13.0.v20230812-1000/com/su
 %changelog
 * Sat Oct 14 2023 manojbaishya <28330014+manojbaishya@users.noreply.github.com> - 4.29-1
 - Release 4.29
+- Add cleanup command for removing directories for different platforms
 * Wed Mar 22 2023 dusansimic <dusan.simic1810@gmail.com> - 4.27-1
 - Release 4.27
 * Mon Dec 26 2022 dusansimic <dusan.simic1810@gmail.com> - 4.26-1

--- a/eclipse-java/eclipse-java.spec
+++ b/eclipse-java/eclipse-java.spec
@@ -3,14 +3,14 @@
 
 %define name eclipse-java
 %define exclusivearch x86_64
-%define rel 2023-03/R
-%define reldash 2023-03-R
+%define rel 2023-09/R
+%define reldash 2023-09-R
 %define srcfilename %{name}-%{reldash}-linux-gtk-%{exclusivearch}.tar.gz
 
 %define _eclipsedir %{_libdir}/eclipse
 
 Name:           %{name}
-Version:        4.27
+Version:        4.29
 Release:        1%{?dist}
 Summary:        Highly extensible IDE (Java version)
 
@@ -53,6 +53,8 @@ done
 %{_datadir}/icons/hicolor/*/apps/eclipse.png
 
 %changelog
+* Sat Oct 14 2023 manojbaishya <28330014+manojbaishya@users.noreply.github.com> - 4.29-1
+- Release 4.29
 * Wed Mar 22 2023 dusansimic <dusan.simic1810@gmail.com> - 4.27-1
 - Release 4.27
 * Mon Dec 26 2022 dusansimic <dusan.simic1810@gmail.com> - 4.26-1

--- a/eclipse-jee/eclipse-jee.spec
+++ b/eclipse-jee/eclipse-jee.spec
@@ -3,14 +3,14 @@
 
 %define name eclipse-jee
 %define exclusivearch x86_64
-%define rel 2023-03/R
-%define reldash 2023-03-R
+%define rel 2023-09/R
+%define reldash 2023-09-R
 %define srcfilename %{name}-%{reldash}-linux-gtk-%{exclusivearch}.tar.gz
 
 %define _eclipsedir %{_libdir}/eclipse
 
 Name:           %{name}
-Version:        4.27
+Version:        4.29
 Release:        1%{?dist}
 Summary:        Highly extensible IDE (Enterprise Java and Web version)
 
@@ -53,6 +53,8 @@ done
 %{_datadir}/icons/hicolor/*/apps/eclipse.png
 
 %changelog
+* Sat Oct 14 2023 manojbaishya <28330014+manojbaishya@users.noreply.github.com> - 4.29-1
+- Release 4.29
 * Wed Mar 22 2023 dusansimic <dusan.simic1810@gmail.com> - 4.27-1
 - Release 4.27
 * Mon Dec 26 2022 dusansimic <dusan.simic1810@gmail.com> - 4.26-1


### PR DESCRIPTION
Hi @dusansimic, I have updated the eclipse-java and eclipse-jee packages to 2023-09-R (4.29) to provide [Java 21 Support for Eclipse 2023-09 (4.29)](https://marketplace.eclipse.org/content/java-21-support-eclipse-2023-09-429).

Following links are reachable:

1. https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/2023-09/R/eclipse-java-2023-09-R-linux-gtk-x86_64.tar.gz&r=1#/eclipse-java-4.29.tar.gz
2. https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/2023-09/R/eclipse-jee-2023-09-R-linux-gtk-x86_64.tar.gz&r=1#/eclipse-jee-4.29.tar.gz

I do not know how to test it though… Can you please run the pipeline and see if the rpm gets built? Thanks!